### PR TITLE
Fixes for #710#issuecomment-297453955

### DIFF
--- a/src/leo_membership_mq_client.erl
+++ b/src/leo_membership_mq_client.erl
@@ -162,7 +162,13 @@ handle_call({consume, Id, MessageBin}) ->
 
     case leo_redundant_manager_api:get_member_by_node(RemoteNode) of
         {ok, #member{state = State}} ->
-            case leo_misc:node_existence(RemoteNode, timer:seconds(10)) of
+            case catch leo_misc:node_existence(RemoteNode, timer:seconds(10)) of
+                {'EXIT', _} ->
+                    % In order to keep the same behavior with <= 1.3.2.1
+                    % by ignoring errors {cause,{noproc,{gen_server,call,[{rex, ...
+                    % Refer https://github.com/leo-project/leofs/issues/710#issuecomment-297453955
+                    % for more detail.
+                    ok;
                 true when State == ?STATE_STOP ->
                     notify_error_to_manager(Id, RemoteNode, Error);
                 true ->


### PR DESCRIPTION
Fix for https://github.com/leo-project/leofs/issues/710#issuecomment-297453955.

Prev this PR
```bash
[E] storage_0@192.168.3.53  2017-04-26 18:28:22.342160 +0300    1493220502  leo_mq_consumer:consume/4   526 [{module,leo_membership_mq_client},{id,mq_persistent_node},{cause,{noproc,{gen_server,call,[{rex,'storage_2@192.168.3.55'},{call,erlang,node,[],<0.47.0>},10000]}}}]
[E] storage_0@192.168.3.53  2017-04-26 18:28:22.353530 +0300    1493220502  leo_mq_consumer:consume/4   526 [{module,leo_membership_mq_client},{id,mq_persistent_node},{cause,{noproc,{gen_server,call,[{rex,'storage_2@192.168.3.55'},{call,erlang,node,[],<0.47.0>},10000]}}}]
[E] storage_0@192.168.3.53  2017-04-26 18:28:22.364200 +0300    1493220502  leo_mq_consumer:consume/4   526 [{module,leo_membership_mq_client},{id,mq_persistent_node},{cause,{noproc,{gen_server,call,[{rex,'storage_2@192.168.3.55'},{call,erlang,node,[],<0.47.0>},10000]}}}]
[E] storage_0@192.168.3.53  2017-04-26 18:28:22.375630 +0300    1493220502  leo_mq_consumer:consume/4   526 [{module,leo_membership_mq_client},{id,mq_persistent_node},{cause,{noproc,{gen_server,call,[{rex,'storage_2@192.168.3.55'},{call,erlang,node,[],<0.47.0>},10000]}}}]
[E] storage_0@192.168.3.53  2017-04-26 18:28:22.387463 +0300    1493220502  leo_mq_consumer:consume/4   526 [{module,leo_membership_mq_client},{id,mq_persistent_node},{cause,{noproc,{gen_server,call,[{rex,'storage_2@192.168.3.55'},{call,erlang,node,[],<0.47.0>},10000]}}}]
```
error logs were filled with the above error after restarting a storage node in a cluster.

After this PR,
Those errors will get disappeared.